### PR TITLE
Improve CPU cluster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# LLM Parallelism Labs
+
+This repository contains example code for training and deploying small language models with different parallelism strategies. The labs are designed for a cluster environment (CPU-only by default) and focus on data parallelism, model fine-tuning, transfer learning, and retrieval-augmented generation (RAG).
+
+The code relies on **torch.distributed** and the HuggingFace `Trainer` to demonstrate four key concepts:
+
+1. **Data Parallelism** – replicate the model across devices and split batches of data.
+2. **Model Parallelism** – partition model layers across devices.
+3. **Pipeline Parallelism** – sequence model stages across processes.
+4. **Tensor Parallelism** – shard individual weight matrices for extreme scale.
+
+## Setup
+
+1. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Launch multi-node jobs with `torchrun` or `deepspeed`. Example for a CPU-only cluster with two processes on one node:
+
+```bash
+torchrun --nnodes 1 --nproc_per_node 2 labs/simple_model/train_simple.py --epochs 1
+```
+
+### Local Dry Run
+
+All training scripts accept a `--dry_run` flag which processes only a handful of
+samples and runs on CPU. This is useful when experimenting without a cluster:
+
+```bash
+python labs/simple_model/train_simple.py --dry_run
+```
+
+### Cluster Launch
+
+On clusters using a workload manager like **Slurm**, jobs can be submitted with
+``torchrun`` inside a batch script.  A template is provided in
+`scripts/slurm_job.sh`:
+
+```bash
+sbatch scripts/slurm_job.sh
+```
+
+## Labs Overview
+
+### Simple Model
+Train a text classifier on the AG News dataset using data parallelism:
+
+```bash
+torchrun --nproc_per_node 2 labs/simple_model/train_simple.py --epochs 1
+```
+
+### Fine Tuning
+Fine-tune a causal language model on WikiText:
+
+```bash
+torchrun --nproc_per_node 2 labs/fine_tuning/fine_tune.py --epochs 1
+```
+
+### Transfer Learning
+Continue training a sequence classifier on the IMDB dataset:
+
+```bash
+torchrun --nproc_per_node 2 labs/transfer_learning/transfer.py --epochs 1
+```
+
+### Retrieval-Augmented Generation
+Run a basic RAG example:
+
+```bash
+python labs/ragging/rag_example.py --query "What is deep learning?"
+```
+
+These scripts are minimal and intended for instructional purposes. Adjust batch sizes and epochs to fit your cluster resources.

--- a/labs/fine_tuning/fine_tune.py
+++ b/labs/fine_tuning/fine_tune.py
@@ -1,0 +1,95 @@
+"""Fine-tune a causal language model with optional distributed training."""
+
+import argparse
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TrainingArguments,
+    Trainer,
+)
+
+from parallel_utils import init_distributed, is_main_process
+
+
+def main():
+    """Fine-tune GPT-style models on a text corpus.
+
+    This script mirrors the HuggingFace trainer example but integrates our
+    distributed utilities.  Use ``--dry_run`` for a tiny dataset slice when
+    experimenting locally.
+    """
+
+    parser = argparse.ArgumentParser(description="Fine-tune a language model with parallelism")
+    parser.add_argument("--model", default="gpt2", help="Base model")
+    parser.add_argument("--dataset", default="wikitext", help="Dataset name")
+    parser.add_argument("--subset", default="wikitext-2-raw-v1", help="Dataset subset")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch_size", type=int, default=2)
+    parser.add_argument("--output_dir", default="./finetuned")
+    parser.add_argument(
+        "--local_rank",
+        type=int,
+        default=os.getenv("LOCAL_RANK", 0),
+        help="Provided by torchrun",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Run only a few samples for quick debugging",
+    )
+    args = parser.parse_args()
+
+    init_distributed(args.local_rank)
+
+    # Load the dataset and tokenizer. GPT2 models require a padding token for batching.
+    dataset = load_dataset(args.dataset, args.subset)
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    def tokenize(batch):
+        return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=128)
+
+    # Tokenize the entire dataset upfront
+    tokenized = dataset.map(tokenize, batched=True)
+    tokenized = tokenized.remove_columns(["text"])
+    tokenized.set_format("torch")
+
+    # Optionally take a very small slice for quick testing
+    train_ds = tokenized["train"]
+    if args.dry_run:
+        train_ds = train_ds.select(range(64))
+
+    model = AutoModelForCausalLM.from_pretrained(args.model)
+
+    # Configure the HuggingFace Trainer. ``gradient_accumulation_steps`` can be
+    # increased to simulate larger batch sizes when compute resources are limited.
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        num_train_epochs=args.epochs,
+        learning_rate=5e-5,
+        evaluation_strategy="no",
+        logging_steps=10,
+        gradient_accumulation_steps=4,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+    )
+
+    trainer.train()
+    if is_main_process():
+        trainer.save_model(args.output_dir)
+
+
+if __name__ == "__main__":
+    # Works on CPU for a dry run or across multiple processes with torchrun
+    main()
+

--- a/labs/ragging/rag_example.py
+++ b/labs/ragging/rag_example.py
@@ -1,0 +1,54 @@
+"""Simple Retrieval-Augmented Generation (RAG) demonstration."""
+
+import argparse
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import RagRetriever, RagTokenizer, RagSequenceForGeneration
+
+from parallel_utils import init_distributed, is_main_process
+
+
+def main():
+    """Run a small RAG example using a Wikipedia corpus."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index_name", default="exact")
+    parser.add_argument("--model_name", default="facebook/rag-sequence-base")
+    parser.add_argument("--dataset", default="wiki_dpr")
+    parser.add_argument("--subset", default="psgs_w100.multiset.small")
+    parser.add_argument("--query", default="What is deep learning?")
+    parser.add_argument(
+        "--local_rank",
+        type=int,
+        default=os.getenv("LOCAL_RANK", 0),
+        help="Used by torchrun",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Load fewer documents for quick testing",
+    )
+    args = parser.parse_args()
+
+    init_distributed(args.local_rank)
+
+    # Restrict the dataset when running a dry run to speed things up
+    split = "train[:50]" if args.dry_run else "train[:500]"
+    dataset = load_dataset(args.dataset, args.subset, split=split)
+    tokenizer = RagTokenizer.from_pretrained(args.model_name)
+    retriever = RagRetriever.from_pretrained(args.model_name, index_name=args.index_name, passages_path=None)
+    model = RagSequenceForGeneration.from_pretrained(args.model_name, retriever=retriever)
+
+    inputs = tokenizer(args.query, return_tensors="pt")
+    with torch.no_grad():
+        generated = model.generate(**inputs)
+    if is_main_process():
+        print(tokenizer.batch_decode(generated, skip_special_tokens=True)[0])
+
+
+if __name__ == "__main__":
+    # Works on a single process or across multiple processes with torchrun
+    main()
+

--- a/labs/simple_model/train_simple.py
+++ b/labs/simple_model/train_simple.py
@@ -1,0 +1,99 @@
+"""Minimal text classification example using data parallelism."""
+
+import argparse
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+    Trainer,
+    TrainingArguments,
+)
+
+from parallel_utils import init_distributed, is_main_process
+
+def main():
+    """Entry point for training.
+
+    Launch this script with ``torchrun`` to enable distributed data
+    parallelism.  Use the ``--dry_run`` flag to execute quickly on a
+    workstation without multiple processes or GPUs.
+    """
+    parser = argparse.ArgumentParser(description="Train a simple classification model with data parallelism")
+    parser.add_argument("--model", default="distilroberta-base", help="Model checkpoint")
+    parser.add_argument("--epochs", type=int, default=1, help="Training epochs")
+    parser.add_argument("--output_dir", default="./model_output", help="Save directory")
+    parser.add_argument("--batch_size", type=int, default=8, help="Per device batch size")
+    parser.add_argument("--lr", type=float, default=5e-5, help="Learning rate")
+    parser.add_argument(
+        "--local_rank",
+        type=int,
+        default=os.getenv("LOCAL_RANK", 0),
+        help="Provided by torchrun for distributed execution",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Run on a small subset of the data for quick local testing",
+    )
+    args = parser.parse_args()
+
+    init_distributed(args.local_rank)
+
+    # Load a small text classification dataset and tokenizer
+    dataset = load_dataset("ag_news")
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+
+    def tokenize(batch):
+        return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=128)
+
+    # Preprocess the dataset. HuggingFace datasets will automatically use
+    # multiprocessing here when available.
+    tokenized = dataset.map(tokenize, batched=True)
+    tokenized = tokenized.rename_column("label", "labels")
+    tokenized.set_format(
+        "torch", columns=["input_ids", "attention_mask", "labels"]
+    )
+
+    model = AutoModelForSequenceClassification.from_pretrained(args.model, num_labels=4)
+
+    # TrainingArguments control the training loop and distributed setup
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        evaluation_strategy="epoch",
+        learning_rate=args.lr,
+        num_train_epochs=args.epochs,
+        logging_dir="./logs",
+        logging_steps=10,
+        dataloader_drop_last=True,
+    )
+
+    # Optionally shrink datasets for a fast dry run
+    train_ds = tokenized["train"]
+    eval_ds = tokenized["test"]
+    if args.dry_run:
+        train_ds = train_ds.select(range(64))
+        eval_ds = eval_ds.select(range(64))
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
+    )
+
+    # Perform training. Only the main process will save the final model to
+    # avoid race conditions when running with multiple ranks.
+    trainer.train()
+    if is_main_process():
+        trainer.save_model(args.output_dir)
+
+if __name__ == "__main__":
+    # When executed directly this will run on a single process.  Use torchrun
+    # for distributed multi-process training.
+    main()
+

--- a/labs/transfer_learning/transfer.py
+++ b/labs/transfer_learning/transfer.py
@@ -1,0 +1,87 @@
+"""Demonstrates transfer learning on the IMDB dataset."""
+
+import argparse
+import os
+
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+    Trainer,
+    TrainingArguments,
+)
+
+from parallel_utils import init_distributed, is_main_process
+
+
+def main():
+    """Fine-tune a classification head on top of a pretrained encoder."""
+
+    parser = argparse.ArgumentParser(description="Transfer learning example")
+    parser.add_argument("--base_model", default="distilbert-base-uncased")
+    parser.add_argument("--dataset", default="imdb")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--output_dir", default="./transfer_model")
+    parser.add_argument(
+        "--local_rank",
+        type=int,
+        default=os.getenv("LOCAL_RANK", 0),
+        help="Assigned by torchrun",
+    )
+    parser.add_argument(
+        "--dry_run",
+        action="store_true",
+        help="Run a quick pass with a handful of samples",
+    )
+    args = parser.parse_args()
+
+    init_distributed(args.local_rank)
+
+    # Load the movie review dataset and tokenizer
+    dataset = load_dataset(args.dataset)
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model)
+
+    def tokenize(batch):
+        return tokenizer(batch['text'], truncation=True, padding='max_length', max_length=128)
+
+    # Preprocess text to tensor format
+    tokenized = dataset.map(tokenize, batched=True)
+    tokenized = tokenized.rename_column("label", "labels")
+    tokenized.set_format(
+        "torch", columns=["input_ids", "attention_mask", "labels"]
+    )
+
+    model = AutoModelForSequenceClassification.from_pretrained(
+        args.base_model, num_labels=2
+    )
+
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=8,
+        evaluation_strategy='epoch',
+        num_train_epochs=args.epochs,
+    )
+
+    # Limit the dataset size when performing a dry run
+    train_ds = tokenized["train"]
+    eval_ds = tokenized["test"]
+    if args.dry_run:
+        train_ds = train_ds.select(range(64))
+        eval_ds = eval_ds.select(range(64))
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
+    )
+    trainer.train()
+    if is_main_process():
+        trainer.save_model(args.output_dir)
+
+
+if __name__ == "__main__":
+    # Execute with torchrun on the cluster or run locally for testing
+    main()
+

--- a/parallel_utils.py
+++ b/parallel_utils.py
@@ -1,0 +1,50 @@
+"""Utility helpers for distributed training.
+
+These functions wrap ``torch.distributed`` initialization so that the same
+training scripts can run both locally on a single process and on a
+multi-node cluster.  When ``WORLD_SIZE`` is greater than ``1`` we prefer the
+``nccl`` backend if GPUs are available and fall back to ``gloo`` for CPU-only
+clusters.  A single-process "gloo" setup keeps the code path consistent during
+dry runs.
+"""
+
+import os
+import torch
+import torch.distributed as dist
+
+
+def init_distributed(local_rank: int) -> None:
+    """Set up ``torch.distributed`` environment.
+
+    Parameters
+    ----------
+    local_rank : int
+        GPU index assigned by ``torchrun``.  When running a CPU-only dry run this
+        value defaults to ``0``.
+    """
+
+    world = int(os.environ.get("WORLD_SIZE", 1))
+    if world > 1:
+        # On a multi-process cluster we prefer NCCL when GPUs are available.
+        # Otherwise fall back to a CPU-only ``gloo`` backend.
+        backend = "nccl" if torch.cuda.is_available() else "gloo"
+        dist.init_process_group(backend)
+        if torch.cuda.is_available():
+            torch.cuda.set_device(local_rank)
+    else:
+        # Single process execution. ``gloo`` works on any hardware.
+        dist.init_process_group("gloo", rank=0, world_size=1)
+
+
+def world_size() -> int:
+    return dist.get_world_size() if dist.is_initialized() else 1
+
+
+def is_main_process() -> bool:
+    """Return ``True`` on rank 0.
+
+    This is useful for logging or saving models only once when running under
+    data parallelism.
+    """
+
+    return (not dist.is_initialized()) or dist.get_rank() == 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+torch==2.2.0
+transformers==4.39.2
+accelerate==0.27.2
+datasets==2.18.0
+deepspeed==0.14.2
+faiss-cpu==1.7.4
+sentencepiece==0.2.0

--- a/scripts/slurm_job.sh
+++ b/scripts/slurm_job.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=llm-lab
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=4
+#SBATCH --cpus-per-task=8
+#SBATCH --time=02:00:00
+
+# Example script for a CPU-only cluster. Remove GPU modules.
+
+export MASTER_PORT=12345
+
+srun torchrun --nnodes $SLURM_JOB_NUM_NODES --nproc_per_node $SLURM_NTASKS_PER_NODE \
+    labs/simple_model/train_simple.py --epochs 1
+


### PR DESCRIPTION
## Summary
- clarify in README that examples target CPU-only clusters
- update distributed helper to pick GLOO when GPUs aren't available
- clean up lab comments to reference multi-process training
- provide a CPU-only Slurm batch script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d756bf89c8326b3572c660bfd9c4e