### PR TITLE
Add TinyLlama distributed Docker workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+# Install git for dataset/tokenizer downloads
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Install CPU-only PyTorch and related libraries
+RUN pip install --no-cache-dir \
+    torch==2.2.0+cpu torchvision==0.17.2+cpu \
+    -f https://download.pytorch.org/whl/cpu/torch_stable.html
+
+RUN pip install --no-cache-dir transformers==4.39.2 datasets==2.18.0
+
+# Copy training script
+COPY fine_tune_tinyllama.py /workspace/
+WORKDIR /workspace
+
+# Default command runs the training script
+ENTRYPOINT ["python", "fine_tune_tinyllama.py"]

--- a/README.md
+++ b/README.md
@@ -73,3 +73,34 @@ python labs/ragging/rag_example.py --query "What is deep learning?"
 ```
 
 These scripts are minimal and intended for instructional purposes. Adjust batch sizes and epochs to fit your cluster resources.
+
+## Docker-Based Multi-Node Training
+
+The repository includes utilities to build a container image and launch
+`fine_tune_tinyllama.py` across multiple hosts. First start a local Docker
+registry:
+
+```bash
+docker run -d -p 5000:5000 --name registry registry:2
+```
+
+Build and push the image:
+
+```bash
+./scripts/push_image.sh
+```
+
+On each node set the environment variables and deploy:
+
+```bash
+export MASTER_IP=<ip-of-node0>
+export NUM_NODES=3
+export PROCS_PER_NODE=4
+export BATCH=1
+export EPOCHS=1
+./scripts/deploy_nodes.sh
+```
+
+`deploy_nodes.sh` runs `torchrun` inside the container with `--network host` so
+the rendezvous uses the host IP/port, mirroring
+[PyTorch's multi-node example](https://pytorch.org/docs/stable/elastic/run.html#distributed-running).

--- a/fine_tune_tinyllama.py
+++ b/fine_tune_tinyllama.py
@@ -1,0 +1,73 @@
+"""Minimal TinyLlama fine-tuning script for distributed CPU clusters."""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader, DistributedSampler
+from torch.nn.parallel import DistributedDataParallel as DDP
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+def init_distributed() -> int:
+    """Initialize ``torch.distributed`` with the gloo backend."""
+    local_rank = int(os.getenv("LOCAL_RANK", 0))
+    dist.init_process_group("gloo")
+    return local_rank
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument(
+        "--local_rank", type=int, default=int(os.getenv("LOCAL_RANK", 0)), help="Provided by torchrun"
+    )
+    args = parser.parse_args()
+
+    local_rank = init_distributed()
+    torch.manual_seed(0)
+
+    # Load tokenizer and dataset
+    tokenizer = AutoTokenizer.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+    tokenizer.pad_token = tokenizer.eos_token
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+
+    def tokenize(batch):
+        return tokenizer(batch["text"], truncation=True, padding="max_length", max_length=128)
+
+    dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
+    dataset.set_format(type="torch")
+
+    sampler = DistributedSampler(dataset)
+    dataloader = DataLoader(dataset, batch_size=args.batch_size, sampler=sampler)
+
+    model = AutoModelForCausalLM.from_pretrained(
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0", output_attentions=True
+    )
+    model = DDP(model)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=5e-5)
+
+    for epoch in range(args.epochs):
+        sampler.set_epoch(epoch)
+        for step, batch in enumerate(dataloader):
+            outputs = model(**batch)
+            loss = outputs.loss
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+
+            if step % 10 == 0 and dist.get_rank() == 0:
+                print(f"Epoch {epoch} Step {step} Loss {loss.item():.4f}")
+            if step % 100 == 0 and dist.get_rank() == 0:
+                ckpt = f"checkpoint_epoch{epoch}_step{step}.pt"
+                torch.save(model.module.state_dict(), ckpt)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_nodes.sh
+++ b/scripts/deploy_nodes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${NUM_NODES:?}"    # total number of nodes
+: "${PROCS_PER_NODE:?}" # processes per node
+: "${MASTER_IP:?}"      # IP address of the master node
+: "${BATCH:?}"         # batch size per process
+: "${EPOCHS:?}"        # number of epochs
+
+IMAGE="my.registry:5000/torch-tinyllama:cpu"
+
+# Pull the latest image from the registry
+docker pull "$IMAGE"
+
+# Stop and remove an existing container if present
+if docker ps -a --format '{{.Names}}' | grep -q '^torch_node$'; then
+    docker stop torch_node
+    docker rm torch_node
+fi
+
+# Launch distributed training using host networking
+docker run -d --name torch_node --network host "$IMAGE" \
+  torchrun \
+  --nnodes="$NUM_NODES" \
+  --nproc_per_node="$PROCS_PER_NODE" \
+  --rdzv_backend=c10d \
+  --rdzv_endpoint="$MASTER_IP:29500" \
+  fine_tune_tinyllama.py \
+  --batch_size "$BATCH" \
+  --epochs "$EPOCHS"

--- a/scripts/push_image.sh
+++ b/scripts/push_image.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="torch-tinyllama:cpu"
+REGISTRY_IMAGE="my.registry:5000/torch-tinyllama:cpu"
+
+# Build the Docker image
+Dockerfile_dir="$(dirname "$(realpath "$0")")/.."
+cd "$Dockerfile_dir"
+docker build -t "$IMAGE" -f Dockerfile .
+
+docker tag "$IMAGE" "$REGISTRY_IMAGE"
+docker push "$REGISTRY_IMAGE"


### PR DESCRIPTION
## Summary
- create Dockerfile installing CPU-only PyTorch and TinyLlama script
- add scripts to build/push the image and deploy across nodes
- implement `fine_tune_tinyllama.py` for distributed training
- document multi-node Docker workflow

## Testing
- `python -m py_compile fine_tune_tinyllama.py`
- `bash -n scripts/push_image.sh`
- `bash -n scripts/deploy_nodes.sh`


------
https://chatgpt.com/codex/tasks/task_e_686fdcb3614c8326bb572e47cb15664a