### PR TITLE
Add detailed comments for teaching

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository contains example code for training and deploying small language 
 
 The code relies on **torch.distributed** and the HuggingFace `Trainer` to demonstrate four key concepts:
 
+See [docs/overview.md](docs/overview.md) for a guided tour of the codebase.
+
 1. **Data Parallelism** – replicate the model across devices and split batches of data.
 2. **Model Parallelism** – partition model layers across devices.
 3. **Pipeline Parallelism** – sequence model stages across processes.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,44 @@
+# Code Overview
+
+This document explains the main components in the repository and how they tie together for distributed language model training. The repository is organized around a set of small examples located under `labs/` and a minimal production-style workflow for fine-tuning TinyLlama.
+
+## Common Utilities
+
+`parallel_utils.py` contains helper functions that wrap `torch.distributed` initialization. The `init_distributed` function configures either NCCL or Gloo backends based on whether GPUs are available. `world_size()` and `is_main_process()` provide simple helpers for querying the distributed environment.
+
+## Fine Tuning TinyLlama
+
+`fine_tune_tinyllama.py` demonstrates how to fine‑tune the [TinyLlama](https://huggingface.co/TinyLlama/TinyLlama-1.1B-Chat-v1.0) model across multiple processes. The script loads the WikiText dataset, tokenizes it, and trains the model using `DistributedDataParallel`. A checkpoint is saved every 100 steps from rank 0 so that only the lead process writes files.
+
+This example can run inside a Docker container using the scripts in the `scripts/` directory.
+
+## Labs Directory
+
+The `labs/` folder provides smaller self‑contained examples focused on different parallelism strategies:
+
+- `simple_model/train_simple.py` — trains a text classifier on the AG News dataset using the HuggingFace `Trainer`. Launching with `torchrun` enables data parallelism.
+- `fine_tuning/fine_tune.py` — fine‑tunes a causal language model. The script mirrors the standard HuggingFace trainer workflow and accepts a `--dry_run` flag for quick CPU‑only testing.
+- `transfer_learning/transfer.py` — demonstrates transfer learning by training a classifier on the IMDB dataset starting from a pretrained encoder.
+- `ragging/rag_example.py` — runs a basic Retrieval‑Augmented Generation (RAG) example on a small Wikipedia subset.
+
+All lab scripts call `init_distributed()` and honor the `--dry_run` option for easy experimentation on a single machine.
+
+## Scripts for Cluster Execution
+
+The `scripts/` directory contains utilities to build and deploy a Docker image or to launch jobs via Slurm:
+
+- `push_image.sh` builds the Docker image and pushes it to a registry.
+- `deploy_nodes.sh` pulls the image on each node and launches `torchrun` with host networking so that all processes can rendezvous.
+- `slurm_job.sh` shows how to submit a multi‑node job on a Slurm cluster using `torchrun`.
+
+## Running Locally
+
+Every training script accepts a `--dry_run` flag to perform a short pass on CPU. This is useful when testing code without a cluster. For example:
+
+```bash
+python labs/simple_model/train_simple.py --dry_run
+```
+
+## Further Reading
+
+Refer to `README.md` in the repository root for high‑level setup instructions and for details on building Docker images for multi‑node training.

--- a/fine_tune_tinyllama.py
+++ b/fine_tune_tinyllama.py
@@ -1,4 +1,12 @@
-"""Minimal TinyLlama fine-tuning script for distributed CPU clusters."""
+"""Fine-tune TinyLlama on a CPU cluster.
+
+This script intentionally keeps the training loop explicit so students can see
+how ``DistributedDataParallel`` is wired up under the hood.  It tokenizes the
+WikiText dataset, shuffles it with a ``DistributedSampler`` and saves periodic
+checkpoints from rank 0 so multiple workers do not contend when writing files.
+Launch with ``torchrun`` to enable multi-process training or run directly for a
+local dry run.
+"""
 
 import argparse
 import os
@@ -12,7 +20,13 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 def init_distributed() -> int:
-    """Initialize ``torch.distributed`` with the gloo backend."""
+    """Initialize ``torch.distributed`` for CPU-only training.
+
+    For simplicity we always use the ``gloo`` backend here which works on any
+    hardware. The returned ``local_rank`` can be used to set the current device
+    when GPUs are available. ``torchrun`` supplies ``LOCAL_RANK`` and other
+    environment variables required by ``DistributedDataParallel``.
+    """
     local_rank = int(os.getenv("LOCAL_RANK", 0))
     dist.init_process_group("gloo")
     return local_rank
@@ -30,7 +44,8 @@ def main() -> None:
     local_rank = init_distributed()
     torch.manual_seed(0)
 
-    # Load tokenizer and dataset
+    # Load tokenizer and dataset.  ``pad_token`` must be set so sequences can be
+    # padded to equal length for batching.
     tokenizer = AutoTokenizer.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0")
     tokenizer.pad_token = tokenizer.eos_token
     dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
@@ -38,12 +53,18 @@ def main() -> None:
     def tokenize(batch):
         return tokenizer(batch["text"], truncation=True, padding="max_length", max_length=128)
 
+    # Tokenization is performed up front so the DataLoader can directly yield
+    # tensors. ``remove_columns`` drops the original text to save memory.
     dataset = dataset.map(tokenize, batched=True, remove_columns=["text"])
     dataset.set_format(type="torch")
 
+    # ``DistributedSampler`` ensures each process receives a unique slice of the
+    # dataset.  Shuffling is handled internally when ``set_epoch`` is called.
     sampler = DistributedSampler(dataset)
     dataloader = DataLoader(dataset, batch_size=args.batch_size, sampler=sampler)
 
+    # Wrap the model with ``DistributedDataParallel`` so gradients are reduced
+    # across all processes during ``backward``.
     model = AutoModelForCausalLM.from_pretrained(
         "TinyLlama/TinyLlama-1.1B-Chat-v1.0", output_attentions=True
     )
@@ -52,6 +73,8 @@ def main() -> None:
     optimizer = torch.optim.AdamW(model.parameters(), lr=5e-5)
 
     for epoch in range(args.epochs):
+        # Calling ``set_epoch`` reshuffles the sampler deterministically so that
+        # each epoch sees a different ordering while keeping processes in sync.
         sampler.set_epoch(epoch)
         for step, batch in enumerate(dataloader):
             outputs = model(**batch)
@@ -63,6 +86,7 @@ def main() -> None:
             if step % 10 == 0 and dist.get_rank() == 0:
                 print(f"Epoch {epoch} Step {step} Loss {loss.item():.4f}")
             if step % 100 == 0 and dist.get_rank() == 0:
+                # Only rank 0 writes checkpoints to avoid file system races.
                 ckpt = f"checkpoint_epoch{epoch}_step{step}.pt"
                 torch.save(model.module.state_dict(), ckpt)
 

--- a/labs/transfer_learning/transfer.py
+++ b/labs/transfer_learning/transfer.py
@@ -1,4 +1,9 @@
-"""Demonstrates transfer learning on the IMDB dataset."""
+"""Demonstrates transfer learning on the IMDB dataset.
+
+The script adds a classification head on top of a pretrained encoder and fine
+tunes it on movie reviews. It reuses the same distributed setup helpers as the
+other labs so that you can scale out the experiment with ``torchrun``.
+"""
 
 import argparse
 import os
@@ -36,6 +41,7 @@ def main():
     )
     args = parser.parse_args()
 
+    # Set up the process group so that the Trainer will synchronize gradients.
     init_distributed(args.local_rank)
 
     # Load the movie review dataset and tokenizer
@@ -76,6 +82,7 @@ def main():
         train_dataset=train_ds,
         eval_dataset=eval_ds,
     )
+    # ``Trainer`` manages the training loop and distributed synchronization.
     trainer.train()
     if is_main_process():
         trainer.save_model(args.output_dir)


### PR DESCRIPTION
## Summary
- expand docstrings and inline comments throughout the training scripts
- clarify distributed helper functions
- document how RAG, transfer learning and fine tuning examples work

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fe3334e248326886ead91f73288cf